### PR TITLE
Fix problem with LICENSE file in binary packages

### DIFF
--- a/makesrpm.sh
+++ b/makesrpm.sh
@@ -51,9 +51,6 @@ trap 'rm -rf "$tmpdir"' EXIT
 %{_libexecdir}/weldr/' "$rpm_name".spec
     fi &&
 
-    # still no clue what this line is supposed to do
-    sed -i '/^mv %{buildroot}%{_ghclicensedir}\/{,ghc-}%{name}/d' "$rpm_name".spec &&
-
     pkgver="$(rpm -q --specfile "${rpm_name}.spec" --qf '%{VERSION}\n' | head -1)" &&
 
     # Create the source archive


### PR DESCRIPTION
after upgrade to cabal-rpm 0.12.1 the LICENSE files are under the
lib subpackage and this script was adding an additional LICENSE file
in the binary RPM causing build failures:

BUILDSTDERR:     Installed (but unpackaged) file(s) found:
BUILDSTDERR:    /usr/share/licenses/bdcs/LICENSE

https://github.com/juhp/cabal-rpm/issues/56